### PR TITLE
Removing Description in Gemspec

### DIFF
--- a/ozonetel.gemspec
+++ b/ozonetel.gemspec
@@ -9,6 +9,7 @@ Gem::Specification.new do |spec|
   spec.authors       = ["vijay yadav"]
   spec.email         = ["vijaynitt12@yahoo.in"]
   spec.summary       = %q{Rest APIs to interact with ozonetel.}
+  spec.description   = %q{Ruby interface for ozonetel APIs}
   spec.homepage      = "https://github.com/urbanladder/ozonetel"
   spec.license       = "MIT"
 

--- a/ozonetel.gemspec
+++ b/ozonetel.gemspec
@@ -9,7 +9,6 @@ Gem::Specification.new do |spec|
   spec.authors       = ["vijay yadav"]
   spec.email         = ["vijaynitt12@yahoo.in"]
   spec.summary       = %q{Rest APIs to interact with ozonetel.}
-  spec.description   = %q{TODO: Write a longer description. Optional.}
   spec.homepage      = "https://github.com/urbanladder/ozonetel"
   spec.license       = "MIT"
 


### PR DESCRIPTION
Since TODO is a reserved keyword and cannot be used for description.
Removing it since it is optional
